### PR TITLE
refactor: a few changes to improve coverage

### DIFF
--- a/systembc/systembc.yara
+++ b/systembc/systembc.yara
@@ -2,6 +2,7 @@ rule win_systembc_20220311 {
     meta:
         author = "Thomas Barabosch, Deutsche Telekom Security"
         twitter = "https://twitter.com/DTCERT"
+        description = "Detects unpacked SystemBC module"
         date = "20220311"
         sharing = "TLP:WHITE"
         malpedia_reference = "https://malpedia.caad.fkie.fraunhofer.de/details/win.systembc"
@@ -10,15 +11,17 @@ rule win_systembc_20220311 {
         hash_1 = "c926338972be5bdfdd89574f3dc2fe4d4f70fd4e24c1c6ac5d2439c7fcc50db5"
         in_memory = "True"
     strings:
-        $s0 = "BEGINDATA" ascii
+        $sx1 = "-WindowStyle Hidden -ep bypass -file" ascii
+        $sx1 = "BEGINDATA" ascii
+        $sx2 = "GET %s HTTP/1.0" ascii
+        /*
         $s1 = "TOR:" ascii
         $s2 = "PORT1:" ascii
-        $s3 = "HOST1:" ascii
-        $s4 = "GET %s HTTP/1.0" ascii
+        $s3 = "HOST1:" ascii 
+        */
         $s5 = "User-Agent:" ascii
-        $s6 = "powershell" ascii
-        $s7 = "-WindowStyle Hidden -ep bypass -file" ascii
+        /* $s6 = "powershell" ascii */
         $s8 = "ALLUSERSPROFILE" ascii
     condition:
-        all of ($s*)
+        ( uint16(0) == 0x5a4d and filesize < 30KB and 2 of ($sx*) ) or all of them
 }

--- a/systembc/systembc.yara
+++ b/systembc/systembc.yara
@@ -12,8 +12,8 @@ rule win_systembc_20220311 {
         in_memory = "True"
     strings:
         $sx1 = "-WindowStyle Hidden -ep bypass -file" ascii
-        $sx1 = "BEGINDATA" ascii
-        $sx2 = "GET %s HTTP/1.0" ascii
+        $sx2 = "BEGINDATA" ascii
+        $sx3 = "GET %s HTTP/1.0" ascii
         /*
         $s1 = "TOR:" ascii
         $s2 = "PORT1:" ascii


### PR DESCRIPTION
Changes that allow it to match on 
- small PE files with a few of the strings
- memory (by removing `filesize` restriction)
- reduce the number of strings by removing short strings that aren't really necessary