### PR TITLE
fix fp in debian

### DIFF
--- a/hacktools/hacktools.yar
+++ b/hacktools/hacktools.yar
@@ -65,7 +65,7 @@ rule cn_utf8_windows_terminal: capability hacktool
         reference = "https://dev.to/mattn/please-stop-hack-chcp-65001-27db"
         reference2 = "https://www.bitdefender.com/files/News/CaseStudies/study/401/Bitdefender-PR-Whitepaper-FIN8-creat5619-en-EN.pdf"
     strings:
-		$a = "chcp 65001" ascii wide
+		$a = " chcp 65001 " ascii wide
     condition:
     	$a
 }


### PR DESCRIPTION
fixes the false positives in debian while still hitting on the examples in the bitdefender report: `cmd /c chcp 65001 & systeminfo`

```
$ grep "chcp 65001" /usr//share/doc/libimage-exiftool-perl/html/faq.html
<li>Type "<code>chcp 65001</code>" then press ENTER at the command prompt.</li>
"<code>chcp 65001</code>" every time "cmd.exe" is launched by changing the
$ grep -a "chcp 65001" /usr//share/code/resources/app/node_modules.asar
  script.push('chcp 65001>nul');
```